### PR TITLE
feat(app/block-sdk): Create upgrade Handlers for block-sdk

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -173,6 +173,7 @@ import (
 	// imports for upgrades
 	v0_1_4 "github.com/cascadiafoundation/cascadia/app/upgrades/v0/v0.1.4"
 	v0_1_5 "github.com/cascadiafoundation/cascadia/app/upgrades/v0/v0.1.5"
+	v0_1_6 "github.com/cascadiafoundation/cascadia/app/upgrades/v0/v0.1.6"
 
 	// block-sdk imports
 	blocksdk "github.com/skip-mev/block-sdk/block"
@@ -1356,6 +1357,16 @@ func (app *Cascadia) setupUpgradeHandlers() {
 			app.appCodec,
 		),
 	)
+
+	//  v0.1.6 upgrade handler
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v0_1_6.UpgradeName,
+		v0_1_6.CreateUpgradeHandler(
+			app.mm, app.configurator,
+			app.AuctionKeeper,
+		),
+	)
+
 	// When a planned update height is reached, the old binary will panic
 	// writing on disk the height and name of the update that triggered it
 	// This will read that value, and execute the preparations for the upgrade.
@@ -1385,6 +1396,12 @@ func (app *Cascadia) setupUpgradeHandlers() {
 			Added: []string{crisistypes.StoreKey, consensusparamtypes.StoreKey, ibcfeetypes.StoreKey},
 		}
 
+	case v0_1_6.UpgradeName:
+		//
+		//
+		storeUpgrades = &storetypes.StoreUpgrades{
+			Added: []string{auctiontypes.StoreKey},
+		}
 	}
 
 	if storeUpgrades != nil {

--- a/app/upgrades/v0/v0.1.6/constants.go
+++ b/app/upgrades/v0/v0.1.6/constants.go
@@ -1,0 +1,6 @@
+package v0_1_6
+
+const (
+	UpgradeName = "v0.1.6"
+	EscrowAddress = "cascadia10a4ps3e5emwnrdfvllnqrnnpfu4zrr26y50p3z"
+)

--- a/app/upgrades/v0/v0.1.6/upgrades.go
+++ b/app/upgrades/v0/v0.1.6/upgrades.go
@@ -1,0 +1,43 @@
+package v0_1_6
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	auctionkeeper "github.com/skip-mev/block-sdk/x/auction/keeper"
+)
+
+// CreateUpgradeHandler creates an SDK upgrade handler for v8
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	// upgrade dependencies
+	ak auctionkeeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		logger.Debug("running module migrations (v0.1.6) ...")
+
+		// update the auction module's escrow address
+		params, err := ak.GetParams(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		// update the auction module's escrow address
+		multiSigAddress, err := sdk.AccAddressFromBech32(EscrowAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		params.EscrowAccountAddress = multiSigAddress
+
+		// set to state
+		if err := ak.SetParams(ctx, params); err != nil {
+			return nil, err
+		}
+
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}


### PR DESCRIPTION
## In This PR
 - I create the upgrade handler for `v0.1.6` (subject to change). This upgrade will
    - Register the `x/auction` module's state in the kv-store
    - Upgrade the EscrowAccount address to cascadia10a4ps3e5emwnrdfvllnqrnnpfu4zrr26y50p3z
## Notice
 - This upgrade is currently not yet scheduled, this will have to be done via gov proposal (or other means)