### PR TITLE
feat(app/block-sdk):set ante-handler on lanes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -941,6 +941,10 @@ func NewCascadia(
 	// set the ante-handlers
 	anteHandler := app.setAnteHandler(encodingConfig.TxConfig, wasmConfig, maxGasWanted)
 
+	baseLane.SetAnteHandler(anteHandler)
+	freeLane.SetAnteHandler(anteHandler)
+	mevLane.SetAnteHandler(anteHandler)
+
 	// initialize stores
 	app.MountKVStores(keys)
 	app.MountTransientStores(tkeys)


### PR DESCRIPTION
## In This PR
 - We update the lanes to correctly reference the application's ante-handler, so that the correct validations can be performed on the txs when ingressed into lanes